### PR TITLE
rename scan state for lexer to `LexerState`

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1,11 +1,11 @@
 use crate::error::LexerError;
-use crate::scanner::{Scanner, ScannerState};
+use crate::scanner::{LexerState, Scanner};
 use crate::token::{Token, TokenType, Tokenizer};
 
 pub struct Lexer<'a> {
     source: &'a str,
     tokens: Vec<Token>,
-    state: ScannerState,
+    state: LexerState,
 }
 
 impl<'a> Lexer<'a> {
@@ -13,7 +13,7 @@ impl<'a> Lexer<'a> {
         Lexer {
             source,
             tokens: Vec::new(),
-            state: ScannerState::new(),
+            state: LexerState::new(),
         }
     }
 
@@ -260,6 +260,17 @@ impl<'a> Scanner for Lexer<'a> {
             .chars()
             .nth(1)
             .unwrap_or('\0')
+    }
+
+    fn previous(&self) -> Self::Item {
+        if self.state.current > 0 {
+            self.source[..self.state.current]
+                .chars()
+                .last()
+                .unwrap_or('\0')
+        } else {
+            '\0'
+        }
     }
 
     fn is_at_end(&self) -> bool {

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -1,14 +1,14 @@
 use std::fmt::Debug;
 
-pub struct ScannerState {
+pub struct LexerState {
     pub start: usize,
     pub current: usize,
     pub line: usize,
 }
 
-impl ScannerState {
+impl LexerState {
     pub fn new() -> Self {
-        ScannerState {
+        LexerState {
             start: 0,
             current: 0,
             line: 1,
@@ -22,5 +22,6 @@ pub trait Scanner {
     fn advance(&mut self) -> Self::Item;
     fn peek(&self) -> Self::Item;
     fn peek_next(&self) -> Self::Item;
+    fn previous(&self) -> Self::Item;
     fn is_at_end(&self) -> bool;
 }


### PR DESCRIPTION
in the middle of implementing the parser, creating a separate state for each makes sense