### PR TITLE
refactor method names for tokenizer trait and lexer

### DIFF
--- a/src/token.rs
+++ b/src/token.rs
@@ -58,11 +58,11 @@ impl<'a> Token<'a> {
     }
 }
 
-pub trait Tokenizer: Scanner {
+pub trait Tokenizer<'a>: Scanner {
     type Token: Debug;
     type TokenType: Debug;
 
     fn tokenize(&mut self) -> Result<Vec<Self::Token>, Self::Error>;
-    fn scan_token(&mut self) -> Result<(), Self::Error>;
-    fn add_token(&mut self, token_type: Self::TokenType);
+    fn next_token(&mut self) -> Result<(Self::TokenType, &'a str), Self::Error>;
+    fn add_token(&mut self, token_type: Self::TokenType, text: &'a str);
 }


### PR DESCRIPTION
makes things a bit clearer, dontcha think? previously the `scan_token` method was doing a bit too much - advancing the state, matching the token type, and adding the token. moving all that to the tokenize method and renaming scan to next and only having it get the next token makes more logical sense